### PR TITLE
Update Dockerfile to use multi-stage build with amazonlinux:2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,30 @@
+# Build 단계
 FROM golang:1.23-alpine AS builder
 
 WORKDIR /app
-
 COPY go.mod go.sum ./
 RUN go mod download
-
 COPY . .
-
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main .
 
-FROM alpine:3.18
+# Runtime 단계
+FROM amazonlinux:2
 
 WORKDIR /app
 
+# AWS CLI, kubectl, token-patch 설치
+RUN yum install -y unzip curl amazon-efs-utils python3 && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip ./aws && \
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl && \
+    mv kubectl /usr/local/bin/ && \
+    curl -L https://raw.githubusercontent.com/kubernetes-sigs/aws-iam-authenticator/v0.5.9/charts/aws-iam-authenticator/files/token.sh -o /usr/local/bin/aws-iam-authenticator && \
+    chmod +x /usr/local/bin/aws-iam-authenticator && \
+    yum clean all
+
 COPY --from=builder /app/main .
-
 EXPOSE 2222
-
 CMD ["./main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /app
 
@@ -7,7 +7,13 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -o main .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main .
+
+FROM alpine:3.18
+
+WORKDIR /app
+
+COPY --from=builder /app/main .
 
 EXPOSE 2222
 


### PR DESCRIPTION
- Implement multi-stage build pattern to optimize final image size
- Use golang:1.23-alpine for go application build
- Switch to amazonlinux:2 base image for aws compatibility
- Add aws cli, kubectl, and aws-iam-authenticator installation
- Remove unnecessary build dependencies

Port: 2222